### PR TITLE
Pin Jenkins agent to a known good version

### DIFF
--- a/vars/inPod.groovy
+++ b/vars/inPod.groovy
@@ -4,7 +4,7 @@ def call(Map args = [:], Closure body) {
   def defaultArgs = [
     cloud: 'CI',
     name: 'pipeline-build',
-    containers: [agentContainer(image: 'jenkins/jnlp-slave:alpine')]
+    containers: [agentContainer(image: 'jenkins/jnlp-slave:3.19-1-alpine')]
   ]
 
   // For containers, add the lists together, but remove duplicates by name,


### PR DESCRIPTION
Looks like the new agent (v3.23-1) sometimes has issues connection to the
master. Use known good version until we figure this out.