### PR TITLE
Use specific credentials for release tool access

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -500,8 +500,8 @@ class Deployer implements Serializable {
       $class: 'GitSCM',
       branches: [[name: 'master']],
       userRemoteConfigs: [[
-        url: 'https://github.com/salemove/release.git',
-        credentialsId: script.scm.userRemoteConfigs.first().credentialsId
+        url: 'git@github.com:salemove/release.git',
+        credentialsId: deployerSSHAgent
       ]],
       extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: releaseProjectSubdir]]
     ])


### PR DESCRIPTION
No need to rely on w/e credentials are used for the main job. Also, the URL
must be an SSH one if credentials are for SSH.