### PR TITLE
Replace --tty & --stdin with --attach in runInKube

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -346,7 +346,7 @@ class Deployer implements Serializable {
               " ${kubernetesDeployment}-checks-${uniqueShortID}" +
               " --image='${finalArgs.image}'" +
               ' --restart=Never' +
-              ' --tty --stdin' +
+              ' --attach' +
               ' --rm' +
               " ${finalArgs.additionalArgs}" +
               " -- ${finalArgs.command}"


### PR DESCRIPTION
--stdin Keep stdin open on the container(s) in the pod, even if nothing
is attached.

--tty Allocated a TTY for each container in the pod.

--attach If true, wait for the Pod to start running, and then attach to
         the Pod as if 'kubectl attach ...' were called. Default false,
         unless '-i/--stdin' is set, in which case the default is true.
         With '--restart=Never' the exit code of the container process
         is returned.

This seems to fix a problem where runInKube logs were not shown in the
CI build.