### PR TITLE
Assume deployer IAM role for deployer pods

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -77,6 +77,11 @@ class Deployer implements Serializable {
   static def volumes(script) {
     [script.secretVolume(mountPath: kubeConfFolderPath, secretName: 'kube-config')]
   }
+  static def annotations(script) {
+    script.withCredentials([script.string(credentialsId: 'eks-deployer-iam-role', variable: 'role')]) {
+      [script.podAnnotation(key: 'iam.amazonaws.com/role', value: script.role)]
+    }
+  }
 
   static def isDeploy(script) {
     def triggerCause = getTriggerCause(script)

--- a/vars/deployer.groovy
+++ b/vars/deployer.groovy
@@ -8,7 +8,8 @@ def wrapPodTemplate(Map args = [:]) {
   // specified args.
   args + [
     containers: addWithoutDuplicates((args.containers ?: []), Deployer.containers(this)) { it.getArguments().name },
-    volumes: addWithoutDuplicates((args.volumes ?: []), Deployer.volumes(this)) { it.getArguments().mountPath }
+    volumes: addWithoutDuplicates((args.volumes ?: []), Deployer.volumes(this)) { it.getArguments().mountPath },
+    annotations: addWithoutDuplicates((args.annotations ?: []), Deployer.annotations(this)) { it.getArguments().key }
   ]
 }
 


### PR DESCRIPTION
This is required for authenticating into EKS clusters.

Potentially, the `wrapPodTemplate` method could be removed in the future.
AFAIK, nested `podTemplate` definitions already inherit all of the attributes
of the outer template, so we could perhaps simply use `inPod` or similar where
we need it, instead of requiring the users to manually wrap their templates.