### PR TITLE
Fix docker image push

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -89,9 +89,9 @@ class Deployer implements Serializable {
   def deploy() {
     github.checkPRMergeable(notifyOnInput: true)
     git.withRemoteTag { version ->
+      pushDockerImage(version)
       inDeployerPod(version) {
         prepareReleaseTool()
-        pushDockerImage(version)
         withRollbackManagement { withLock ->
           withLock('acceptance-environment') { deploy, rollBackForLockedResource ->
             deploy(env: envs.acceptance, version: version)


### PR DESCRIPTION
If the deployer pod runs on a different node from the original pod, then docker
push may currently push a completely different image.

Jenkins' docker plugin refers to images by their tag. If images are built with
e.g. `docker.build('project-name')` (i.e. without specifying some sort of
`:v1.2.3` tag or similar), which is what we normally do, then the plugin will
refer to those images [by `project-name:latest`][1]. Now, the catch is, that it
doesn't differentiate between different images with the same tag.

This causes a couple of issues. For one, if somebody builds another image with
the same tag on the same host before the deployer pushes the docker image, then
deployer might be pushing a completely different image from the one the user
expects. Second, when the deployer pod runs on a different host, it uses the
`project-name:latest` image from that host, which will very likely be
a different image from the one the user expected.

This change fixes the second issue. The second issue was introduced recently by
doing the docker push step in a different pod from the one where docker build
was run. See f6e8c3c ("Remove wrapPodTemplate", 2018-09-07).

Unfortunately, there's no way to fix the first issue at the level of this
library. A quick workaround would be to specify a unique tag for docker builds,
a la `docker.build("project-name:${UUID}")`, but this has to be done by every
user of this library. A better approach would be to fix the docker plugin, so
that it uses the `--iidfile` build flag to get a unique identifier of the built
image and to only use that ID for other operations.

[1]: https://github.com/jenkinsci/docker-workflow-plugin/blob/50ad50bad2ee14eb73d1ae3ef1058b8ad76c9e5d/src/main/java/org/jenkinsci/plugins/docker/workflow/ImageNameTokens.java#L57