### PR TITLE
Fix checking out a specific tag

### DIFF
--- a/src/com/salemove/deploy/Git.groovy
+++ b/src/com/salemove/deploy/Git.groovy
@@ -59,9 +59,10 @@ class Git implements Serializable {
     script.checkout(
       $class: 'GitSCM',
       branches: [[name: "refs/tags/${tagName(version)}"]],
-      doGenerateSubmoduleConfigurations: script.scm.doGenerateSubmoduleConfigurations,
-      extensions: script.scm.extensions,
-      userRemoteConfigs: script.scm.userRemoteConfigs
+      userRemoteConfigs: [[
+        url: script.scm.userRemoteConfigs.url,
+        credentialsId: deployerSSHAgent
+      ]]
     )
   }
 


### PR DESCRIPTION
The solution for checking out a tag was based on an [SO answer][1] for this
exact question. However, in addition to what was described in that answer, the
solution here also included additional configurations and extensions from the
`scm` global variable. This included the [`MergeWithGitSCMExtension`
extension][2] and a very specific `userRemoteConfigs.refspec`, in the following
form.

```
+refs/pull/962/head:refs/remotes/origin/PR-962 +refs/heads/master:refs/remotes/origin/master
```

Avoid including these and only include the essential: the repository URL. We
assume elsewhere that our SSH agent credentials have access to every repository
managed by this library, so using our own credentials just simplifies things.

[1]: https://stackoverflow.com/a/34437541/1456578
[2]: https://github.com/jenkinsci/git-plugin/blob/70634f15702157af3a5b7f49e953882c45e438df/src/main/java/jenkins/plugins/git/MergeWithGitSCMExtension.java