### PR TITLE
Add overwriteEntrypoint flag for runInKube

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,7 @@ withResultReporting(slackChannel: '#tm-is') {
         def deployVersion = sh(script: 'git log -n 1 --pretty=format:\'%h\'', returnStdout: true).trim()
         env['runInKube'](
           command: './test.sh',
+          overwriteEntrypoint: true,
           additionalArgs: "--env='BUILD_VALUE=${expectedBuildValue(buildVersion)}'" +
             " --env='TEMPLATE_VALUE=${expectedTemplateValue(deployVersion, env.name)}'"
         )

--- a/README.adoc
+++ b/README.adoc
@@ -118,27 +118,28 @@ The exact changes required depend on the project, but here's an example.
 +    env['runInKube'](
 +      image: '662491802882.dkr.ecr.us-east-1.amazonaws.com/smoke-test-repo:latest', // <3>
 +      command: './run_smoke_tests.sh',
-+      additionalArgs: '--env="FOO=bar" --port=12345' // <4>
++      overwriteEntrypoint: true, // <4>
++      additionalArgs: '--env="FOO=bar" --port=12345' // <5>
 +    )
 +    if (env.name == 'acceptance') {
 +      runAcceptanceTests(
 +        driver: 'chrome',
 +        visitorApp: 'v2',
-+        suite: 'acceptance_test_pattern[lib/engagement/omnicall/.*_spec.rb]', // <5>
++        suite: 'acceptance_test_pattern[lib/engagement/omnicall/.*_spec.rb]', // <6>
 +        slackChannel: '#tm-engage,
 +        parallelTestProcessors: 1
 +      )
 +    }
 +  },
 +  checklistFor: { env ->
-+    def dashboardURL = "https://app.datadoghq.com/dash/206940?&tpl_var_KubernetesCluster=${env.name}" // <6>
-+    def logURL = "https://logs.${env.domainName}/app/kibana#/discover?_g=" + // <7>
++    def dashboardURL = "https://app.datadoghq.com/dash/206940?&tpl_var_KubernetesCluster=${env.name}" // <7>
++    def logURL = "https://logs.${env.domainName}/app/kibana#/discover?_g=" + // <8>
 +      '(time:(from:now-30m,mode:quick,to:now))&_a=' +
 +      '(query:(language:lucene,query:\'application:call_router+AND+level:error\'))'
 +
 +    [[
-+      name: 'dashboard', // <8>
-+      description: "<a href=\"${dashboardURL}\">The project dashboard (${dashboardURL})</a> looks OK" // <9>
++      name: 'dashboard', // <9>
++      description: "<a href=\"${dashboardURL}\">The project dashboard (${dashboardURL})</a> looks OK" // <10>
 +    ], [
 +      name: 'logs',
 +      description: "No new errors in <a href=\"${logURL}\">the project logs (${logURL})</a>"
@@ -156,14 +157,18 @@ Jenkinsfile.
 <2> No need to push the image to anywhere. Just build it and pass to
 `deployOnCommentTrigger`, which tags and pushes as required.
 <3> The image defaults to the current version of the application image.
-<4> Additional arguments to `kubectl run`.
-<5> The tests and the other checks run in acceptance obviously vary by project.
-<6> Use `env.name` to customize links for the specific environment. It's one
+<4> Optional. Defaults to `false`. If true, then `command` will overwrite the
+container's entrypoint, instead of being used as its arguments. In Kubernetes
+terms, the `command` will be specified as the `command` field for the
+container, instead of `args`.
+<5> Optional. Additional arguments to `kubectl run`.
+<6> The tests and the other checks run in acceptance obviously vary by project.
+<7> Use `env.name` to customize links for the specific environment. It's one
 of: `acceptance`, `beta`, `prod-us`, and `prod-eu`.
-<7> Use `env.domainName` to customize URLs. For example, it's
+<8> Use `env.domainName` to customize URLs. For example, it's
 `beta.salemove.com` in beta and `salemove.com` in prod US.
-<8> This should be a simple keyword.
-<9> Blue Ocean UI https://issues.jenkins-ci.org/browse/JENKINS-41162[currently]
+<9> This should be a simple keyword.
+<10> Blue Ocean UI https://issues.jenkins-ci.org/browse/JENKINS-41162[currently]
 doesn't display links, while the old one does. This means that links have to
 also be included in plain text, for Blue Ocean UI users to see/access them.
 

--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -335,6 +335,7 @@ class Deployer implements Serializable {
         runInKube: { Map args ->
           def defaultArgs = [
             image: "${dockerRegistryURI}/${image.id.replaceFirst(/:.*$/, '')}:${version}",
+            overwriteEntrypoint: false,
             additionalArgs: ''
           ]
           def finalArgs = defaultArgs << args
@@ -349,6 +350,7 @@ class Deployer implements Serializable {
               ' --attach' +
               ' --rm' +
               " ${finalArgs.additionalArgs}" +
+              " ${finalArgs.overwriteEntrypoint ? '--command' : ''}" +
               " -- ${finalArgs.command}"
             )
           }


### PR DESCRIPTION
From Kubernetes help documentation:

> --command=false: If true and extra arguments are present, use them as the
'command' field in the container, rather than the 'args' field which is the
default.

Currently users of this library had to provide `--command` in `additionalArgs`
to be able to overwrite the entrypoint. This change makes it simpler.