### PR TITLE
Add no-env-lock argument

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -389,7 +389,7 @@ class Deployer implements Serializable {
         parameters: checklist.collect { script.booleanParam(it + [defaultValue: false]) }
       )
 
-      // input returns just the value if it has only one paramter, and a map of
+      // input returns just the value if it has only one parameter, and a map of
       // values otherwise. Create a list of names that have `false` values from
       // that response.
       def uncheckedResponses

--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -5,7 +5,18 @@ import com.salemove.deploy.Github
 import com.salemove.deploy.Notify
 
 class Deployer implements Serializable {
-  public static final triggerPattern = '!deploy'
+  public static final triggerPattern = /
+    |(?sx)          # Enable flags: DOTALL (dot matches newlines) and COMMENTS (enable these regex comments)
+    |\A
+    |\s*            # Allow optional whitespace before the command
+    |!deploy
+    |(?:            # Don't capture the whitespace before arguments
+      |\s+          # Force whitespace between command and arguments
+      |(?<args>.*?) # Capture arguments with group named "args", non-greedy to avoid capturing trailing whitespace
+    |)?             # Arguments are optional
+    |\s*            # Allow optional whitespace after the command
+    |\z
+  /.stripMargin().trim()
 
   private static final containerName = 'deployer-container'
   private static final kubeConfFolderPath = '/root/.kube_conf'

--- a/src/com/salemove/deploy/Args.groovy
+++ b/src/com/salemove/deploy/Args.groovy
@@ -1,0 +1,6 @@
+package com.salemove.deploy
+
+
+class Args implements Serializable {
+  public static final noEnvLock = 'no-env-lock'
+}

--- a/src/com/salemove/deploy/Notify.groovy
+++ b/src/com/salemove/deploy/Notify.groovy
@@ -1,5 +1,7 @@
 package com.salemove.deploy
 
+import com.salemove.deploy.Args
+
 class Notify implements Serializable {
   private def script, kubernetesDeployment, kubernetesNamespace
   Notify(script, args) {
@@ -84,6 +86,12 @@ class Notify implements Serializable {
     script.pullRequest.comment(
       "@${deployingUser()}, the changes were validated in acceptance. Please click **Proceed**" +
       " ${hereMDJobLink()} to continue the deployment."
+    )
+  }
+  def unexpectedArgs() {
+    script.pullRequest.comment(
+      "Sorry, I don't understand. I only support the '${Args.noEnvLock}' argument." +
+      " Check the logs ${hereMDJobLink()} for more information."
     )
   }
 

--- a/vars/deployer.groovy
+++ b/vars/deployer.groovy
@@ -30,6 +30,8 @@ def wrapProperties(providedProperties = []) {
   ]
 
   if (isDeploy) {
+    Deployer.validateTriggerArgs(this)
+
     tags.add("github_user=${Deployer.deployingUser(this)}")
 
     // Stop all previous builds that are still in progress


### PR DESCRIPTION
Some deploys don't really affect the rest of the system and aren't affected
by it. They can now be deployed with `!deploy no-env-lock`, which only
grabs the lock per project per env, and not just per env. I.e. It can be
deployed simultaneously with other projects, but deploys within the same
project behave as before.

This is really just a quick band aid on the underlying issue of needing
more sophisticated and granular locking protocol. Let's see how far this
gets us, however.

One problem with this is, that now these jobs aren't guarded against
selenium cluster restarts either. Unfortunately there's no way to implement
such a guard without forcing the same cluster-wide lock until [Jenkin
starts differentiating between shared and exclusive locks][1]. If it would,
we could acquire a read lock for `selenium-restart` here, and a write
(exclusive) lock for the same resource when the Selenium cluster is being
restarted.

More info in commits.

[1]: https://issues.jenkins-ci.org/browse/JENKINS-38852