### PR TITLE
Allow specifying version for Ruby build agent

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -258,12 +258,22 @@ NOTE: `inDockerAgent` is a derivative of <<code-inpod-code>>, so everything
 that applies to `inPod` also applies to `inDockerAgent`.
 
 === `inRubyBuildAgent`
+:link-docker-repository-tags: https://hub.docker.com/r/salemove/jenkins-agent-ruby/tags/
 
 A pod template for building Ruby projects. Comes with an agent container
-with Ruby and Docker support and PostgreSQL and RabbitMQ containers.
+with Ruby and Docker support and PostgreSQL and RabbitMQ containers. Ruby version
+is configurable via `rubyVersion` parameter and defaults to `2.4`. All available
+versions can be found in {link-docker-repository-tags}[Docker repository].
 
 NOTE: `inRubyBuildAgent` is a derivative of <<code-inpod-code>>, so everything
 that applies to `inPod` also applies to `inRubyBuildAgent`.
+
+Example:
+[source,groovy]
+----
+inRubyBuildAgent(
+  rubyVersion: '2.5' // Optional, defaults to 2.4
+)
 
 === `passiveContainer`
 

--- a/vars/inRubyBuildAgent.groovy
+++ b/vars/inRubyBuildAgent.groovy
@@ -6,10 +6,12 @@ def call(Map args = [:], Closure body) {
     usernameVariable: 'dbUser',
     passwordVariable: 'dbPass'
   )]) {
+    def rubyVersion = args.rubyVersion ?: '2.4'
+
     def defaultArgs = [
       name: 'pipeline-ruby-build',
       containers: [
-        agentContainer(image: 'salemove/jenkins-agent-ruby:2.4.1'),
+        agentContainer(image: "salemove/jenkins-agent-ruby:${rubyVersion}"),
         passiveContainer(
           name: 'db',
           image: 'postgres:9.5.7-alpine',


### PR DESCRIPTION
For backwards-compatibility default Ruby version is kept at 2.4,
but patch version requirement is removed for easier upgrades when
security patches are released.