### PR TITLE
Update JNLP slave (Jenkins agent) versions

### DIFF
--- a/vars/inDockerAgent.groovy
+++ b/vars/inDockerAgent.groovy
@@ -3,7 +3,7 @@ import static com.salemove.Collections.addWithoutDuplicates
 def call(Map args = [:], Closure body) {
   def defaultArgs = [
     name: 'pipeline-docker-build',
-    containers: [agentContainer(image: 'salemove/jenkins-agent-docker:17.12.0')],
+    containers: [agentContainer(image: 'salemove/jenkins-agent-docker:17.12.0-0dc8e6a')],
     volumes: [hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
   ]
 

--- a/vars/inPod.groovy
+++ b/vars/inPod.groovy
@@ -4,7 +4,7 @@ def call(Map args = [:], Closure body) {
   def defaultArgs = [
     cloud: 'CI',
     name: 'pipeline-build',
-    containers: [agentContainer(image: 'jenkins/jnlp-slave:3.19-1-alpine')]
+    containers: [agentContainer(image: 'jenkins/jnlp-slave:3.26-1-alpine')]
   ]
 
   // For containers, add the lists together, but remove duplicates by name,


### PR DESCRIPTION
The only update in the docker image is the upgrade of the same `jnlp-slave`
base image.