### PR TITLE
Add rollback link to Slack notifications

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -274,6 +274,7 @@ Example:
 inRubyBuildAgent(
   rubyVersion: '2.5' // Optional, defaults to 2.4
 )
+----
 
 === `passiveContainer`
 

--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -244,6 +244,7 @@ class Deployer implements Serializable {
 
     def env = finalArgs.env
     def version = finalArgs.version
+    def repository = git.getRepositoryName()
 
     def kubectlCmd = "kubectl" +
       " --kubeconfig=${kubeConfFolderPath}/config" +
@@ -255,7 +256,7 @@ class Deployer implements Serializable {
       " --context '${env.kubeContext}'" +
       " --namespace ${kubernetesNamespace}" +
       " --application ${kubernetesDeployment}" +
-      " --repository ${git.getRepositoryName()}" +
+      " --repository ${repository}" +
       ' --no-release-managed' +
       ' --pod-node-selector role=application'
 
@@ -327,7 +328,7 @@ class Deployer implements Serializable {
           def rollbackVersion = getCurrentVersion(kubectlCmd)
           if (rollbackVersion) {
             rollBack = rollbackForVersion(rollbackVersion)
-            notify.envDeploying(env, version, rollbackVersion)
+            notify.envDeploying(env, version, rollbackVersion, repository)
           } else {
             if (env.name == 'acceptance') {
               // User might not be watching the job logs at this stage. Notify them via GitHub.

--- a/src/com/salemove/deploy/Notify.groovy
+++ b/src/com/salemove/deploy/Notify.groovy
@@ -23,10 +23,13 @@ class Notify implements Serializable {
     ])
   }
 
-  def envDeploying(env, version, rollbackVersion) {
+  def envDeploying(env, version, rollbackVersion, repository) {
+    def rollbackLink = env.name == 'acceptance' ?  '' :
+      " (<${rollbackURL(env, rollbackVersion, repository)}|roll back>)"
+
     sendSlack(env, [
       message: "${deployingUser()} is updating ${deployedResouce()} to version ${version}" +
-        " in ${env.displayName}. The current version is ${rollbackVersion}."
+        " in ${env.displayName}. The current version is ${rollbackVersion}${rollbackLink}."
     ])
   }
   def envDeploySuccessful(env, version) {
@@ -120,5 +123,13 @@ class Notify implements Serializable {
   private def deployedResouce() {
     "deployment/${kubernetesDeployment}" +
       (kubernetesNamespace == 'default' ? '' : " in ${kubernetesNamespace} namespace")
+  }
+
+  private def rollbackURL(env, rollbackVersion, repository) {
+    'https://jobs.salemove.com/job/deploy-kubernetes-by-revision/parambuild/' +
+    "?repository=${repository}" +
+    "&service=${kubernetesDeployment}" +
+    "&revision=${rollbackVersion}" +
+    "&environment=${env.kubeEnvName}"
   }
 }


### PR DESCRIPTION
This allows for quick rollback when this deploy pipeline has finished. This
is for cases when reverting the faulty commits and deploying them is too
slow. The currently running version of the application can quickly be
deployed with a click of a button. The user will be asked for confirmation
after clicking the link.

INF-1819