### PR TITLE
Add email notifications to withResultReporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def expectedResponse = { buildVersion, deployVersion, envName ->
 
 properties(deployer.wrapProperties())
 
-withResultReporting(slackChannel: '#tm-is') {
+withResultReporting(slackChannel: '#tm-inf') {
   inDockerAgent(deployer.wrapPodTemplate()) {
     checkout(scm)
     def buildVersion = sh(script: 'git log -n 1 --pretty=format:\'%h\'', returnStdout: true).trim()

--- a/README.adoc
+++ b/README.adoc
@@ -413,17 +413,14 @@ withResultReporting(customMessage: "Build was started with: ${params.buildParam}
 ----
 
 If `mailto` argument has been specified, then a notification is also sent to the
-email, specified in this argument. The logic is the same as in
-**E-mail notification** post-build action of {link-mailer-plugin}[Mailer plugin]:
-
-- For a failed build a notification is always sent, and 100 last lines of console
-log are included into the notification.
-- For a successful built a notification is only sent if the previous build failed.
+email, specified in this argument. The wording is similar to the one in
+**E-mail notification** post-build action of {link-mailer-plugin}[Mailer plugin].
+For a failed build, 250 last lines of console log are also included into the
+notification (the length is configurable via `maxLogLines` argument).
 [source,groovy]
 ----
 withResultReporting(
   slackChannel: '#tm-inf',
-  strategy: 'onFailure',
   mailto: 'operations@salemove.com'
 ) {
   inPod {

--- a/README.adoc
+++ b/README.adoc
@@ -354,9 +354,10 @@ WARNING: Only specify the `name`, `workingDir`, `command`, `args`, and/or
 `ttyEnabled` fields for `agentContainer` if you know what you're doing.
 
 === `withResultReporting`
+:link-mailer-plugin: https://wiki.jenkins.io/display/JENKINS/Mailer
 
 A scripted pipeline footnote:[As opposed to declarative pipelines.]
-wrapper that sends build status notifications to Slack.
+wrapper that sends build status notifications to Slack and optionally email.
 
 Without specifying any arguments it sends Slack notifications to the #ci
 channel whenever a master branch build status changes from success to failure
@@ -410,6 +411,27 @@ withResultReporting(customMessage: "Build was started with: ${params.buildParam}
   }
 }
 ----
+
+If `mailto` argument has been specified, then a notification is also sent to the
+email, specified in this argument. The logic is the same as in
+**E-mail notification** post-build action of {link-mailer-plugin}[Mailer plugin]:
+
+- For a failed build a notification is always sent, and 100 last lines of console
+log are included into the notification.
+- For a successful built a notification is only sent if the previous build failed.
+[source,groovy]
+----
+withResultReporting(
+  slackChannel: '#tm-is',
+  strategy: 'onFailure',
+  mailto: 'operations@salemove.com'
+) {
+  inPod {
+    // Do something
+  }
+}
+----
+
 
 == Developing
 

--- a/README.adoc
+++ b/README.adoc
@@ -386,7 +386,7 @@ properties([
   pipelineTriggers([cron('30 10 * * 5')])
 ])
 
-withResultReporting(slackChannel: '#tm-is', strategy: 'onFailure') {
+withResultReporting(slackChannel: '#tm-inf', strategy: 'onFailure') {
   inPod {
     // Do something
   }
@@ -422,7 +422,7 @@ log are included into the notification.
 [source,groovy]
 ----
 withResultReporting(
-  slackChannel: '#tm-is',
+  slackChannel: '#tm-inf',
   strategy: 'onFailure',
   mailto: 'operations@salemove.com'
 ) {

--- a/vars/withResultReporting.groovy
+++ b/vars/withResultReporting.groovy
@@ -25,35 +25,16 @@ def call(Map args = [:], Closure body) {
   def mailSend = { mailArgs ->
     def from = JenkinsLocationConfiguration.get().getAdminAddress()
     def buildId = "${env.JOB_NAME} ${currentBuild.displayName}"
-<<<<<<< HEAD
-||||||| parent of 98d3742... fixup! Add email notifications
-    def body = "${env.BUILD_URL}"
-    if (args.log) {
-        def consoleLog = currentBuild.rawBuild.getLog(100).join('<br>')
-        body = "${body}<br><br>${consoleLog}"
-    }
-=======
-    def body = "${env.BUILD_URL}"
+    def mailBody = "${env.BUILD_URL}"
     if (mailArgs.log) {
-        def consoleLog = currentBuild.rawBuild.getLog(100).join('<br>')
-        body = "${body}<br><br>${consoleLog}"
+      def consoleLog = currentBuild.rawBuild.getLog(100).join('<br>')
+      mailBody = "${mailBody}<br><br>${consoleLog}"
     }
->>>>>>> 98d3742... fixup! Add email notifications
     mail(
       from: from,
-<<<<<<< HEAD
-      to: args.to,
-      subject: "${args.message}: ${buildId}",
-      body: "${env.BUILD_URL}",
-||||||| parent of 98d3742... fixup! Add email notifications
-      to: args.to,
-      subject: "${args.message}: ${buildId}",
-      body: body,
-=======
       to: mailArgs.to,
       subject: "${mailArgs.message}: ${buildId}",
-      body: body,
->>>>>>> 98d3742... fixup! Add email notifications
+      body: mailBody,
       mimeType: 'text/html',
       cc: '',
       bcc: '',
@@ -108,12 +89,12 @@ def call(Map args = [:], Closure body) {
           def lastResult = retrieveLastResult(currentBuild)
           if (lastResult != 'SUCCESS') {
             def message = "Jenkins build is back to normal"
-            mailSend([message: message, to: finalArgs.mailto])
+            mailSend(message: message, to: finalArgs.mailto)
           }
           break
         case 'FAILURE':
           def message = "Build failed in Jenkins"
-          mailSend([message: message, to: finalArgs.mailto])
+          mailSend(message: message, to: finalArgs.mailto, log: true)
           break
       }
     }

--- a/vars/withResultReporting.groovy
+++ b/vars/withResultReporting.groovy
@@ -4,7 +4,8 @@ def call(Map args = [:], Closure body) {
   def defaultArgs = [
     slackChannel: '#ci',
     mainBranch: 'master',
-    strategy: 'onMainBranchChange'
+    strategy: 'onMainBranchChange',
+    maxLogLines: 250
   ]
   def finalArgs = defaultArgs << args
 
@@ -31,7 +32,7 @@ def call(Map args = [:], Closure body) {
     def buildId = "${env.JOB_NAME} ${currentBuild.displayName}"
     def mailBody = "${env.BUILD_URL}"
     if (mailArgs.log) {
-      def consoleLog = currentBuild.rawBuild.getLog(100).join('<br>')
+      def consoleLog = currentBuild.rawBuild.getLog(finalArgs.maxLogLines).join('<br>')
       mailBody = "${mailBody}<br><br>${consoleLog}"
     }
     mail(

--- a/vars/withResultReporting.groovy
+++ b/vars/withResultReporting.groovy
@@ -45,7 +45,7 @@ def call(Map args = [:], Closure body) {
   try {
     body()
   } catch (e) {
-    currentBuild.result = 'FAILED'
+    currentBuild.result = 'FAILURE'
     throw e
   } finally {
     // currentBuild.result of null indicates success.


### PR DESCRIPTION
[INF-1815](https://salemove.atlassian.net/browse/INF-1815)

At least two pipeline jobs that are using `withResultReporting` wrapper, also need email notification. So far it was done as a hack:

* https://github.com/salemove/ansible/pull/794
* https://github.com/salemove/jenkins_scripts/pull/11

With this change, email notifications become a part of the wrapper.
