### PR TITLE
Fix withResultReporting failures in non-multibranch jobs

### DIFF
--- a/vars/withResultReporting.groovy
+++ b/vars/withResultReporting.groovy
@@ -64,7 +64,7 @@ def call(Map args = [:], Closure body) {
     switch(finalArgs.strategy) {
       case 'onMainBranchChange':
         def statusChanged = retrieveLastResult(currentBuild) != currentResult
-        if (statusChanged && BRANCH_NAME == finalArgs.mainBranch) {
+        if (statusChanged && env.BRANCH_NAME == finalArgs.mainBranch) {
           if (currentResult == 'SUCCESS') {
             slackSend(channel: finalArgs.slackChannel, color: 'good', message: "Success: ${buildDescription}")
             mailSend(to: finalArgs.mailto, message: "Jenkins build is back to normal")


### PR DESCRIPTION
[INF-1815](https://salemove.atlassian.net/browse/INF-1815)

After adding email notification to withResultReporting, we started calling it from non-multibranch jobs, where BRANCH_NAME variable is not defined. Such jobs fail with MissingPropertyException.

Using `env.` prefix is not mandatory since Pipeline Plugin 2.18 ([1]), however, it looks like it is still requierd when we want Groovy to gracefully return `null` if the property does not exist:
```
// prints "false"
echo("${env.BRANCH_NAME == 'master'}")
// fails with MissingPropertyException.
echo("${BRANCH_NAME == 'master'}")
```
[1]: https://wiki.jenkins.io/display/JENKINS/Pipeline+Groovy+Plugin#PipelineGroovyPlugin-2.18(Sep23,2016)