### PR TITLE
Use kube-config ConfigMap instead of Secret

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -493,7 +493,7 @@ class Deployer implements Serializable {
       script.inDockerAgent(
         name: 'deployer',
         containers: [script.interactiveContainer(name: containerName, image: 'salemove/jenkins-toolbox:327930e')],
-        volumes: [script.secretVolume(mountPath: kubeConfFolderPath, secretName: 'kube-config')],
+        volumes: [script.configMapVolume(mountPath: kubeConfFolderPath, configMapName: 'kube-config')],
         annotations: [script.podAnnotation(key: 'iam.amazonaws.com/role', value: script.role)]
       ) {
         git.checkoutVersionTag(version)


### PR DESCRIPTION
The data doesn't contain any secret information any longer and so can be and
has been converted into a ConfigMap. The Secret currently still exists until
its users (e.g. this) are updated.

INF-1833