### PR TITLE
Broadcast important messages to the channel

### DIFF
--- a/src/com/salemove/deploy/Notify.groovy
+++ b/src/com/salemove/deploy/Notify.groovy
@@ -49,6 +49,7 @@ class Notify implements Serializable {
   def envRollbackFailed(env, rollbackVersion) {
     sendSlack(env, [
       color: 'danger',
+      replyBroadcast: true,
       message: "Failed to roll back ${deployedResouce()} to version ${rollbackVersion}" +
         " in ${env.displayName}. Manual intervention is required!"
     ])
@@ -61,6 +62,7 @@ class Notify implements Serializable {
   def envDeployDeletionFailed(env) {
     sendSlack(env, [
       color: 'danger',
+      replyBroadcast: true,
       message: "Failed to roll back ${deployedResouce()} by deleting it" +
         " in ${env.displayName}. Manual intervention is required!"
     ])
@@ -73,6 +75,7 @@ class Notify implements Serializable {
   def envUndoFailed(env) {
     sendSlack(env, [
       color: 'danger',
+      replyBroadcast: true,
       message: "Failed to undo update to ${deployedResouce()} in ${env.displayName}." +
         ' Manual intervention is required!'
     ])


### PR DESCRIPTION
My [PR for that feature for the Slack plugin][1] was just merged and released,
so now we can broadcast important messages to the channel while still sending
them to the thread as well.

[1]: https://github.com/jenkinsci/slack-plugin/pull/473