### PR TITLE
Fix updateStaticAssets stashing everything

### DIFF
--- a/vars/deployer.groovy
+++ b/vars/deployer.groovy
@@ -71,7 +71,7 @@ def buildImageIfDoesNotExist(Map args, Closure body) {
 }
 
 def updateStaticAssets(Map args) {
-  stash(name: 'assets', include: "${args.assetsFolder}/**/*")
+  stash(name: 'assets', includes: "${args.assetsFolder}/**/*")
   if (args.integritiesFile) {
     stash(name: 'integrities', includes: args.integritiesFile)
   }


### PR DESCRIPTION
A typo caused the `includes` field to be unset so that it defaults to `**` and
causes `stash` to stash all the files in the working directory. It doesn't
break anything, but is very wasteful, as the stash has to be stored on Jenkins
master. From the docs:

> *Note* that the `stash` and `unstash` steps are designed for use with small
files. For large data transfers, use the External Workspace Manager plugin, or
use an external repository manager such as Nexus or Artifactory. This is
because stashed files are archived in a compressed TAR, and with large files
this demands considerable on-master resources, particularly CPU time. There's
not a hard stash size limit, but between 5-100 MB you should probably consider
alternatives.

INF-1859