### PR TITLE
Increase memory limit of deploy test pod

### DIFF
--- a/config/kubernetes/deploy-pipeline-test.template
+++ b/config/kubernetes/deploy-pipeline-test.template
@@ -22,10 +22,10 @@ spec:
       - name: deploy-pipeline-test
         resources:
           requests:
-            memory: "4Mi"
+            memory: "10Mi"
             cpu: "2m"
           limits:
-            memory: "10Mi"
+            memory: "30Mi"
             cpu: "2m"
         image: '662491802882.dkr.ecr.us-east-1.amazonaws.com/deploy-pipeline-test:{{APP_VERSION}}'
         ports:


### PR DESCRIPTION
A new version of runc [doesn't work well][1] with very small memory limits.

[1]: https://github.com/opencontainers/runc/issues/1980#issuecomment-463148112