### PR TITLE
Allow specifying name for runInKube

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -127,6 +127,7 @@ The exact changes required depend on the project, but here's an example.
 +    env['runInKube'](
 +      image: '662491802882.dkr.ecr.us-east-1.amazonaws.com/smoke-test-repo:latest', // <6>
 +      command: './run_smoke_tests.sh',
++      name: 'call-router-deploy-test', // Optional. Default is based on kubernetesDeployment value
 +      overwriteEntrypoint: true, // Optional, defaults to `false` <7>
 +      additionalArgs: '--env="FOO=bar" --port=12345' // Optional <8>
 +    )

--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -395,18 +395,19 @@ class Deployer implements Serializable {
     script.stage("Running automatic checks in ${env.displayName}") {
       automaticChecksFor(env.subMap(['name', 'domainName']) << [
         runInKube: { Map args ->
+          def uniqueShortID = UUID.randomUUID().toString().replaceFirst(/^.*-/, '')
           def defaultArgs = [
             image: "${dockerRegistryURI}/${image.id.replaceFirst(/:.*$/, '')}:${version}",
+            name: "${kubernetesDeployment}-checks-${uniqueShortID}",
             overwriteEntrypoint: false,
             additionalArgs: ''
           ]
           def finalArgs = defaultArgs << args
 
-          def uniqueShortID = UUID.randomUUID().toString().replaceFirst(/^.*-/, '')
           script.ansiColor('xterm') {
             script.sh(
               "${kubectlCmd} run" +
-              " ${kubernetesDeployment}-checks-${uniqueShortID}" +
+              " ${finalArgs.name}" +
               " --image='${finalArgs.image}'" +
               ' --restart=Never' +
               ' --attach' +


### PR DESCRIPTION
This sets the name for the pod and the container. It's necessary to be able to
define the container name to be able to use `--overrides` in `additionalArgs`
to add e.g. `volumes` and `volumeMounts`.