### PR TITLE
Avoid updating static asset versions during ATs

### DIFF
--- a/vars/deployer.groovy
+++ b/vars/deployer.groovy
@@ -136,12 +136,14 @@ def deployAssetsVersion(Map args) {
   }
 
   inToolbox {
-    def script = "${releaseProjectSubdir}/update_static_asset_versions"
-    if (args.integritiesFile) {
-      unstash(integritiesStash)
-      sh("${script} ${args.version} ${args.integritiesFile}")
-    } else {
-      sh("${script} ${args.version}")
+    lock('acceptance-environment') {
+      def script = "${releaseProjectSubdir}/update_static_asset_versions"
+      if (args.integritiesFile) {
+        unstash(integritiesStash)
+        sh("${script} ${args.version} ${args.integritiesFile}")
+      } else {
+        sh("${script} ${args.version}")
+      }
     }
   }
 }


### PR DESCRIPTION
I was investigating an acceptance test failure and saw that `api` and
`operator-app-launcher` pods were all deleted during the failure. Turns out
`visitor-app` master branch had recently been updated and it updated static
asset versions, which script also deletes all pods that use the changed asset
revisions, including `api` and `operator-app-launcher`.

This change doesn't allow this to happen during acceptance tests anymore,
hopefully providing additional stability for these tests.

INF-1919