### PR TITLE
Put deployer pods onto role=application nodes

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -493,7 +493,14 @@ class Deployer implements Serializable {
         name: 'deployer',
         containers: [script.interactiveContainer(name: containerName, image: 'salemove/jenkins-toolbox:327930e')],
         volumes: [script.configMapVolume(mountPath: kubeConfFolderPath, configMapName: 'kube-config')],
-        annotations: [script.podAnnotation(key: 'iam.amazonaws.com/role', value: script.role)]
+        annotations: [script.podAnnotation(key: 'iam.amazonaws.com/role', value: script.role)],
+        yaml: '''\
+          apiVersion: v1
+          kind: Pod
+          spec:
+            nodeSelector:
+              role: application
+        '''
       ) {
         git.checkoutVersionTag(version)
         body()


### PR DESCRIPTION
These pods can be long-lived, so putting them onto `role=jenkins` nodes, as we
do now, is problematic. The `role=jenkins` nodes get get terminated every
evening, causing any pending deploys to fail.

The fix here is to put them onto `role=application` nodes which don't get
deleted. Another option would be to make these pods resilient to deletions, but
that's a much greater effort.

This problem doesn't affect other pods running on `role=jenkins`, because most
of them are short-lived and can be restarted without issues.