### PR TITLE
Fix CPS method mismatch warnings

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -383,7 +383,7 @@ class Deployer implements Serializable {
       script.echo('`inAcceptance` is deprecated. Please use `automaticChecksFor` instead.')
 
       script.stage('Running acceptance tests') {
-        inAcceptance()
+        inAcceptance.call()
       }
     }
 
@@ -393,7 +393,7 @@ class Deployer implements Serializable {
     }
 
     script.stage("Running automatic checks in ${env.displayName}") {
-      automaticChecksFor(env.subMap(['name', 'domainName']) << [
+      automaticChecksFor.call(env.subMap(['name', 'domainName']) << [
         runInKube: { Map args ->
           def uniqueShortID = UUID.randomUUID().toString().replaceFirst(/^.*-/, '')
           def defaultArgs = [
@@ -430,7 +430,7 @@ class Deployer implements Serializable {
         return
       }
 
-      def checklist = checklistFor(env.subMap(['name', 'domainName']))
+      def checklist = checklistFor.call(env.subMap(['name', 'domainName']))
       if (checklist.size() == 0) {
         script.input(question)
         return


### PR DESCRIPTION
Every deploy currently outputs warnings like the following, one or more per
env.

> expected to call com.salemove.Deployer.automaticChecksFor but wound up
catching org.jenkinsci.plugins.workflow.cps.CpsClosure2.call; see:
https://jenkins.io/redirect/pipeline-cps-method-mismatches/

According to [the updated link][1], this is due to a common false
positive:

> Unfortunately, some expressions may incorrectly trigger this warning
even though they execute correctly. [..] In Groovy, an expression like
`object.fn()` is statically ambiguous and could be one of a few things.
[..] The code that detects CPS method mismatches cannot currently
distinguish between these cases, and so the second two examples issue
a warning even though they are correct [..]. As a workaround, when you are
invoking a closure, you can explicitly call `Closure.call` rather than
using Groovy syntactic sugar.

And this is exactly what this change is.

[1]: https://wiki.jenkins.io/display/JENKINS/Pipeline+CPS+method+mismatches