### PR TITLE
Retry merging to master

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -600,7 +600,15 @@ class Deployer implements Serializable {
     // Mark the current job's status as success, for the PR to be mergeable.
     github.setStatus(status: 'success', description: 'The PR has successfully been deployed')
 
-    git.finishMerge()
+    script.retry(3) {
+      try {
+        git.finishMerge()
+      } catch(e) {
+        script.echo("Merge failed with the following exception. Waiting a bit and trying again. ${e}!")
+        script.sleep(time: 5, unit: 'SECONDS')
+        throw(e)
+      }
+    }
   }
 
   private def pushDockerImage(String version) {


### PR DESCRIPTION
There's reason to believe that sometimes GitHub can fail the merge due to
pending status checks even though we just updated the commit statuses. The
assumption here is that it happens because the update hasn't fully propagated
yet. If that's the case, then waiting a little and trying again should help us
recover in these cases.