### PR TITLE
Retry setting GitHub status to success before merge

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -597,11 +597,11 @@ class Deployer implements Serializable {
   }
 
   private def mergeToMaster() {
-    // Mark the current job's status as success, for the PR to be mergeable.
-    github.setStatus(status: 'success', description: 'The PR has successfully been deployed')
-
     script.retry(3) {
       try {
+        // Mark the current job's status as success, for the PR to be mergeable.
+        github.setStatus(status: 'success', description: 'The PR has successfully been deployed')
+
         git.finishMerge()
       } catch(e) {
         script.echo("Merge failed with the following exception. Waiting a bit and trying again. ${e}!")


### PR DESCRIPTION
Commit 179b5fb ("Retry merging to master", 2019-09-05) was trying to fix an
issue where `git.finishMerge()` would fail with:
```
+ git push origin @:master
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: 3 of 3 required status checks are expected.
To github.com:<repo>.git
 ! [remote rejected] @ -> master (protected branch hook declined)
error: failed to push some refs to 'git@github.com:<repo>.git'
```

But looks like the fix didn't work, at least not completely. In this case,
when checking GitHub, the statuses managed by `github.setStatus` were both
in the pending state, even hours after the merge failure. This means that
`github.setStatus` didn't seem to do its job. If there's some intermittent
failure that can cause this, then moving the step into the retry block
should help.