### PR TITLE
Add functions to read Ansible run results

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -514,6 +514,55 @@ deployer.publishDocs(
 )
 ----
 
+=== `ansiblePlaybookWithResults` and `buildWithResults`
+
+Two wrappers around `ansiblePlaybook()` and `build()` pipeline steps respectively,
+designed to obtain variables, registered by the Ansible playbook.
+[source,groovy]
+----
+def buildResult, ansibleVars = buildWithResults(
+  job: 'ansible/run-playbook',
+  parameters: [
+    string(name: 'playbook', value: 'db-provision-hosts.yml'),
+    // other parameters
+  ]
+)
+----
+
+The above syntax expects that the `ansible/run-playbook` Jenkins job invokes
+`ansiblePlaybookWithResults()` when running the playbook (instead of the standard
+`ansiblePlaybook()`). This ensures the results are passed within build variables
+in serialised form and can be later deserialised by `buildWithResults()` and
+returned as the second element of the returning tuple.
+
+Registering variables is done in Ansible by calling `register-jenkins-variable`
+role. There are two ways of doing so: directly or from a task.
+[source,yaml]
+----
+  roles:
+    - role: register-jenkins-variable
+      jenkins_var_name: 'var1'
+      jenkins_var_value: "value1"
+  tasks:
+    - name: Save IP of DB master for Jenkins
+      include_role:
+        name: register-jenkins-variable
+      vars:
+        jenkins_var_name: 'var2'
+        jenkins_var_value: "variable2"
+----
+
+With the given variables registered by the Ansible playbook, the following code
+will print `value1` and `value2`:
+[source,groovy]
+----
+def buildResult, ansibleVars = buildWithResults(
+  // build parameters
+  )
+echo(ansibleVars.var1)
+echo(ansibleVars.var2)
+----
+
 == Developing
 
 Guard is used for providing a preview of the documentation. Run the following

--- a/vars/ansiblePlaybookWithResults.groovy
+++ b/vars/ansiblePlaybookWithResults.groovy
@@ -1,0 +1,27 @@
+import groovy.json.JsonBuilder
+
+def call(Map args = [:]) {
+  def defaultArgs = [
+    jenkinsVarsDir: 'jenkins-variables',
+  ]
+
+  def finalArgs = defaultArgs << args
+
+  def registerAnsibleVars(jenkinsVarsDir) {
+    echo("Loading registered variables from Ansible...")
+    def vars = [:]
+    varNames = sh(
+      script: "ls ${jenkinsVarsDir}",
+      returnStdout: true
+      ).trim().split()
+    varNames.each {
+      vars.put(it, readFile("${jenkinsVarsDir}/${it}"))
+    }
+    def builder = new JsonBuilder()
+    builder(vars)
+    env.ansibleVarsJson = builder.toString()
+  }
+
+  ansiblePlaybook(args)
+  registerAnsibleVars(finalArgs.jenkinsVarsDir)
+}

--- a/vars/buildWithResults.groovy
+++ b/vars/buildWithResults.groovy
@@ -1,0 +1,16 @@
+import groovy.json.JsonSlurperClassic
+
+def call(Map args = [:]) {
+
+  def getAnsibleVars(buildResult) {
+    def buildVars = buildResult.getBuildVariables()
+    def ansibleVarsJson = buildVars.ansibleVarsJson
+    assert ansibleVarsJson: "No results found - make sure to call ansiblePlaybookWithResults"
+    def slurper = new JsonSlurperClassic()
+    return slurper.parseText(ansibleVarsJson)
+  }
+
+  def buildResult = build(args)
+  def ansibleVars = getAnsibleVars(buildResult)
+  return [buildResult, ansibleVars]
+}


### PR DESCRIPTION
[INF-2074](https://salemove.atlassian.net/browse/INF-2074)

`ansiblePlaybookWithResults()` runs a playbook that is expected to store results in a serialised form. `buildWithResults()` is able to retrieve and deserialise these results.