### PR TITLE
Fix ansiblePlaybookWithResults without results

### DIFF
--- a/vars/ansiblePlaybookWithResults.groovy
+++ b/vars/ansiblePlaybookWithResults.groovy
@@ -6,7 +6,7 @@ def call(Map args = [:], String jenkinsVarsDir = 'jenkins-variables') {
   echo("Loading registered variables from Ansible...")
   def vars = [:]
   varNames = sh(
-    script: "ls ${jenkinsVarsDir}",
+    script: "ls ${jenkinsVarsDir} 2>/dev/null || true",
     returnStdout: true
   ).trim().split()
   varNames.each {


### PR DESCRIPTION
INF-2074

Follow-up to https://github.com/salemove/pipeline-lib/pull/97. Fix failure in case if the playbook invoked by `ansiblePlaybookWithResults()` does not register anything (and therefore hasn't created `ansible-variables` directory).