### PR TITLE
Update Jenkins base image for docker agent

### DIFF
--- a/vars/inDockerAgent.groovy
+++ b/vars/inDockerAgent.groovy
@@ -3,7 +3,7 @@ import static com.salemove.Collections.addWithoutDuplicates
 def call(Map args = [:], Closure body) {
   def defaultArgs = [
     name: 'pipeline-docker-build',
-    containers: [agentContainer(image: 'salemove/jenkins-agent-docker:17.12.0-0dc8e6a')],
+    containers: [agentContainer(image: 'salemove/jenkins-agent-docker:17.12.0-be4ccb0')],
     volumes: [hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
   ]
 


### PR DESCRIPTION
The new version pulls changes from [Update base image version for agents to
3.36-2][1]. The description of the update:

> The latest versions support establishing a connection between master and the
agents over a direct TCP connection, slightly simplifying the startup of
agents. Update the base image to support this in these agent images as well.
See https://github.com/jenkinsci/kubernetes-plugin/pull/602 for more
information.

[1]: https://github.com/salemove/docker-jenkins-agents/pull/11