### PR TITLE
Update k8s apiVersion for Deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def actualResponse = { envName, domainName ->
   def response
   container('deployer-container') {
     response = sh(
-      script: "curl -H 'Host: ${projectName}.${domainName}' gateway.${domainName}",
+      script: "curl -H 'Host: ${projectName}.${domainName}' https://gateway.${domainName}",
       returnStdout: true
     ).trim()
   }

--- a/config/kubernetes/deploy-pipeline-test.template
+++ b/config/kubernetes/deploy-pipeline-test.template
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deploy-pipeline-test


### PR DESCRIPTION
These APIs have been deprecated and will be removed in k8s 1.16. We are on
1.14 now, but will be upgrading to new versions as soon as they are released.
This will keep us prepared for this and enables experimenting with local
clusters of newer k8s versions.

According to [docs about the upgrade][1]:

> * Deployment in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 API versions is no longer served
>   * Migrate to use the apps/v1 API version, available since v1.9. Existing persisted data can be retrieved/updated via the new version.
>   * Notable changes:
>     * `spec.rollbackTo` is removed
>     * `spec.selector` is now required and immutable after creation
>     * `spec.progressDeadlineSeconds` now defaults to `600` seconds
>     * `spec.revisionHistoryLimit` now defaults to `10`
>     * `maxSurge` and `maxUnavailable` now default to `25%`

[1]: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/