### PR TITLE
Add timestamps printer to jobs

### DIFF
--- a/vars/inPod.groovy
+++ b/vars/inPod.groovy
@@ -44,7 +44,9 @@ def call(Map args = [:], Closure body) {
     label: podLabel,
   ]) {
     node(podLabel) {
-      body()
+      wrap([$class: 'TimestamperBuildWrapper']) {
+        body()
+      }
     }
   }
 }


### PR DESCRIPTION
TimestamperBuildWrapper plugin can work inside node only.
We execute the code in Pods, adding timestamper to Pod wrapper will give us time tracking in the Job logs.