### PR TITLE
Disable implicit nesting-based inheritance for pods

### DIFF
--- a/vars/inPod.groovy
+++ b/vars/inPod.groovy
@@ -6,6 +6,7 @@ def call(Map args = [:], Closure body) {
     cloud: 'CI',
     name: 'pipeline-build',
     containers: [agentContainer(image: 'jenkins/jnlp-slave:3.36-2-alpine')],
+    inheritFrom: '',
     yaml: '''\
       apiVersion: v1
       kind: Pod


### PR DESCRIPTION
As described in [Jenkins kubernetes-plugin documentation][1]:

> In many cases it would be useful to define and compose podTemplates directly
> in the pipeline using groovy. This is made possible via nesting. You can nest
> multiple pod templates together in order to compose a single one.
>
> [..]
>
> There are cases where this implicit inheritance via nested declaration is
> not wanted or another explicit inheritance is preferred. In this case, use
> inheritFrom '' to remove any inheritance [..].

In our case this nesting has always been around but it has never been
intentionally used for composition. Rather, it has effectively just piled on
unrelated containers for pods created deep in the pipelines. This is further
shown by the fact that all of these helper functions immediately call `node`.
The idea with nesting suggests multiple layers of `podTemplate` before calling
`node`, which is not possible with these helpers.

As an example of the problems caused by this nesting, let's look at an example
build. It is not uncommon for a build to include e.g. a language container and
additional containers for PostgreSQL and RabbitMQ. Then from the same build the
deployment pipeline is started which then in turn starts a pipeline for
acceptance tests. By the end of all that there are acceptance-test pods with
nine (nine!) containers while they really need three plus jnlp.

This change removes that unnecessary burden by turning the implicit inheritance
off by default. It should still be possible to use this inheritance if
necessary by passing `inheritFrom: null` explicitly.

Other helpers build on top of `inPod` so they will receive the same
configuration.

[1]: https://github.com/jenkinsci/kubernetes-plugin/tree/d9cf6a810fce807fe35cd56ebe17ffb343c702f4#nesting-pod-templates