### PR TITLE
Deploy to Production sequentially when pre-deployment checks are defined

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -133,12 +133,22 @@ class Deployer implements Serializable {
             deploy(env: envs.beta, version: version)
             waitForValidationIn(envs.beta)
             notify.prodDeploying(version)
-            script.parallel(
-              US: { deploy(env: envs.prodUS, version: version) },
-              EU: { deploy(env: envs.prodEU, version: version) }
-            )
-            waitForValidationIn(envs.prodUS)
-            waitForValidationIn(envs.prodEU)
+
+            if (!preDeploymentChecksFor) {
+              script.parallel(
+                US: { deploy(env: envs.prodUS, version: version) },
+                EU: { deploy(env: envs.prodEU, version: version) }
+              )
+              waitForValidationIn(envs.prodUS)
+              waitForValidationIn(envs.prodEU)
+            } else {
+              deploy(env: envs.prodUS, version: version)
+              waitForValidationIn(envs.prodUS)
+
+              deploy(env: envs.prodEU, version: version)
+              waitForValidationIn(envs.prodEU)
+            }
+
             withLock(testEnvLock(onlyLocal: true)) { deployWithATLock, _ ->
               deployWithATLock(env: envs.acceptance, version: version, runAutomaticChecks: false)
             }


### PR DESCRIPTION
When pre-deployment checks require some user input (that's what they
were designed for), deploying in parallel makes things cumbersome:
1. User must abort ALL parallel branches, aborting just one doesn't have
   the desired effect.
2. Request for input from multiple branches may lost in the old UI,

For now the solution is to simply force sequential mode if
pre-deployment checks are defined. In the future we can develop some API
for that.