### PR TITLE
Notify when changes deployed to beta

### DIFF
--- a/src/com/salemove/Deployer.groovy
+++ b/src/com/salemove/Deployer.groovy
@@ -131,6 +131,7 @@ class Deployer implements Serializable {
             git.checkMasterHasNotChanged()
             github.checkPRMergeable(notifyOnInput: false)
             deploy(env: envs.beta, version: version)
+            notify.inputRequiredInBeta()
             waitForValidationIn(envs.beta)
             notify.prodDeploying(version)
 

--- a/src/com/salemove/deploy/Notify.groovy
+++ b/src/com/salemove/deploy/Notify.groovy
@@ -101,6 +101,11 @@ class Notify implements Serializable {
       " ${hereMDJobLink()} to continue the deployment."
     )
   }
+  def inputRequiredInBeta() {
+    script.pullRequest.comment(
+      "@${deployingUser()}, the changes have been deployed to beta. Please continue ${hereMDJobLink()}."
+    )
+  }
   def unexpectedArgs() {
     script.pullRequest.comment(
       "Sorry, I don't understand. I only support the '${Args.noGlobalLock}' argument." +


### PR DESCRIPTION
With this commit a comment is added to the pull request when changes
have been deployed to beta and are pending validation.
This feature is useful as people may forget that they are deploying,
especially when they have to wait behind locks.