### PR TITLE
Add log rotation after one year by default

### DIFF
--- a/vars/deployer.groovy
+++ b/vars/deployer.groovy
@@ -47,7 +47,9 @@ def wrapProperties(providedProperties = []) {
     }
   }
 
-  providedProperties + [
+  [
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '365', artifactNumToKeepStr: '', daysToKeepStr: '365', numToKeepStr: ''))
+  ] + providedProperties + [
     pipelineTriggers([issueCommentTrigger(Deployer.triggerPattern)]),
     [
       $class: 'DatadogJobProperty',


### PR DESCRIPTION
For branch ci, we have a permanent master branch with unlimited builds history.
Some of the projects using artefacts to save heavy files between the builds, 
in such cases it brings us to the storage problem. 

To solve it all at once we set the default retention to 1 year which can be overridden.

INF-2298