### PR TITLE
Gracefully handle malformed Slack responses

### DIFF
--- a/src/com/salemove/Communication.groovy
+++ b/src/com/salemove/Communication.groovy
@@ -1,0 +1,51 @@
+package com.salemove
+
+class Communication {
+  static final SLACK_RETRIES = 3
+
+  static def safeSlackSend(script, Map args) {
+    // Wrapper around Jenkins' own `slackSend` that will retry the sending process and finally ask for permission
+    // to proceed with the pipeline w/o notifications.
+    int retries = 0
+    def slackResp
+
+    while (retries < SLACK_RETRIES) {
+      try {
+        slackResp = script.slackSend([:] << args)
+
+        if (!slackResp) {
+          retries++
+          script.echo("Got an empty response from Slack, retrying (${retries}/${SLACK_RETRIES})...")
+        } else {
+          break
+        }
+      } catch(e) {
+        retries++
+        script.echo("Caught an exception while trying to send a Slack message, retrying (${retries}/${SLACK_RETRIES})...")
+      }
+    }
+
+    if (!slackResp) {
+      if (script.env.CHANGE_ID) {
+        // We're likely in a Pull Request
+        def deployingUser = script.currentBuild.rawBuild.getCause(
+            org.jenkinsci.plugins.pipeline.github.trigger.IssueCommentCause
+          ).userLogin
+        def hereMDJobLink = "[here](${script.RUN_DISPLAY_URL}) (or [in the old UI](${script.BUILD_URL}/console))"
+
+        try {
+          script.pullRequest.comment("@${deployingUser}, Slack notifications failed, your input is required ${hereMDJobLink()}.")
+        } catch(e) {
+          script.echo("Failed to make a PR comment regarding user input.")
+        }
+      }
+
+      script.input(
+        "Could not send a notification to Slack. If Slack works as expected, click 'Abort'." +
+        "You should only proceed without a Slack notification in case of an emergency."
+      )
+    } else {
+      return slackResp
+    }
+  }
+}

--- a/src/com/salemove/deploy/Notify.groovy
+++ b/src/com/salemove/deploy/Notify.groovy
@@ -1,6 +1,7 @@
 package com.salemove.deploy
 
 import com.salemove.deploy.Args
+import static com.salemove.Communication.safeSlackSend
 
 class Notify implements Serializable {
   private def script, kubernetesDeployment, kubernetesNamespace, threadIds
@@ -116,7 +117,7 @@ class Notify implements Serializable {
   private def sendSlack(slackChannel, Map args) {
     // The << operator mutates the left-hand map. Start with an empty map ([:])
     // to avoid mutating user-provided object.
-    def resp = script.slackSend([:] << args << [
+    def resp = safeSlackSend(script, [:] << args << [
       channel: threadIds[slackChannel] ?: slackChannel,
       message: "${args.message}" +
         "\n<${script.pullRequest.url}|PR ${script.pullRequest.number} - ${script.pullRequest.title}>" +

--- a/vars/withResultReporting.groovy
+++ b/vars/withResultReporting.groovy
@@ -1,4 +1,5 @@
 import jenkins.model.*
+import static com.salemove.Communication.safeSlackSend
 
 def call(Map args = [:], Closure body) {
   def defaultArgs = [
@@ -55,7 +56,7 @@ def call(Map args = [:], Closure body) {
   def threadId
   def sendStartMessage = { ->
     if (finalArgs.strategy == 'always') {
-      def resp = slackSend(channel: finalArgs.slackChannel, message: "Started: ${buildDescription}")
+      def resp = safeSlackSend(this, [channel: finalArgs.slackChannel, message: "Started: ${buildDescription}"])
       threadId = resp.threadId
     }
   }
@@ -75,37 +76,37 @@ def call(Map args = [:], Closure body) {
       case 'onMainBranchChange':
         if (statusChanged && env.BRANCH_NAME == finalArgs.mainBranch) {
           if (currentResult == 'SUCCESS') {
-            slackSend(channel: finalArgs.slackChannel, color: 'good', message: "Success: ${buildDescription}")
+            safeSlackSend(this, [channel: finalArgs.slackChannel, color: 'good', message: "Success: ${buildDescription}"])
             mailSend(to: finalArgs.mailto, message: "Jenkins build is back to normal")
           } else {
-            slackSend(channel: finalArgs.slackChannel, color: 'danger', message: "Failure: ${buildDescription}")
+            safeSlackSend(this, [channel: finalArgs.slackChannel, color: 'danger', message: "Failure: ${buildDescription}"])
             mailSend(to: finalArgs.mailto, message: "Build failed in Jenkins", log: true)
           }
         }
         break
       case 'onFailure':
         if (currentResult != 'SUCCESS') {
-          slackSend(channel: finalArgs.slackChannel, color: 'danger', message: "Failure: ${buildDescription}")
+          safeSlackSend(this, [channel: finalArgs.slackChannel, color: 'danger', message: "Failure: ${buildDescription}"])
           mailSend(to: finalArgs.mailto, message: "Build failed in Jenkins", log: true)
         }
         break
       case 'onFailureAndRecovery':
         if (currentResult == 'SUCCESS') {
           if (statusChanged) {
-            slackSend(channel: finalArgs.slackChannel, color: 'good', message: "Success: ${buildDescription}")
+            safeSlackSend(this, [channel: finalArgs.slackChannel, color: 'good', message: "Success: ${buildDescription}"])
             mailSend(to: finalArgs.mailto, message: "Jenkins build is back to normal")
           }
         } else {
-          slackSend(channel: finalArgs.slackChannel, color: 'danger', message: "Failure: ${buildDescription}")
+          safeSlackSend(this, [channel: finalArgs.slackChannel, color: 'danger', message: "Failure: ${buildDescription}"])
           mailSend(to: finalArgs.mailto, message: "Build failed in Jenkins", log: true)
         }
         break
       case 'always':
         if (currentResult == 'SUCCESS') {
-          slackSend(channel: threadId, color: 'good', message: "Success: ${buildDescription}")
+          safeSlackSend(this, [channel: threadId, color: 'good', message: "Success: ${buildDescription}"])
           mailSend(to: finalArgs.mailto, message: "Jenkins build successful")
         } else {
-          slackSend(channel: threadId, color: 'danger', replyBroadcast: true, message: "Failure: ${buildDescription}")
+          safeSlackSend(this, [channel: threadId, color: 'danger', replyBroadcast: true, message: "Failure: ${buildDescription}"])
           mailSend(to: finalArgs.mailto, message: "Build failed in Jenkins", log: true)
         }
         break


### PR DESCRIPTION
In some instances the response from Slack service is used
in further logic. Thus an empty/failed `slackSend` ends up
with a pipeline failure.
This change introduces a new wrapper function `safeSlackSend`
that will retry sending to Slack and finally ask the triggerer
whether it is OK to proceed w/o Slack message.

Part of INF-2398