### PR TITLE
Allow using BuildKit when running `inDockerAgent`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ def expectedResponse = { buildVersion, deployVersion, envName ->
 properties(deployer.wrapProperties())
 
 withResultReporting(slackChannel: '#tm-inf') {
-  inDockerAgent(deployer.wrapPodTemplate()) {
+  inDockerAgent(useBuildKit: true) {
     checkout(scm)
     def buildVersion = sh(script: 'git log -n 1 --pretty=format:\'%h\'', returnStdout: true).trim()
     def image = deployer.buildImageIfDoesNotExist(name: projectName) {

--- a/README.adoc
+++ b/README.adoc
@@ -323,6 +323,7 @@ share the same `workingDir`, which makes them work nicely together.
 
 === `inDockerAgent`
 :link-docker-build: https://jenkins.io/doc/book/pipeline/docker/#building-containers
+:link-docker-buildkit: https://docs.docker.com/develop/develop-images/build_enhancements/
 
 A pod template for building docker containers.
 
@@ -331,6 +332,9 @@ container named `jnlp`, in which all commands will run by default, unless
 the container is changed with `container`.] which supports building docker
 images. So if you need to run {link-docker-build}[`docker.build`], use
 `inDockerAgent` instead of `inPod`.
+
+`inDockerAgent` accepts argument `useBuildKit: true` which forces Docker to use
+{link-docker-buildkit}[BuildKit] for building images.
 
 NOTE: `inDockerAgent` is a derivative of <<code-inpod-code>>, so everything
 that applies to `inPod` also applies to `inDockerAgent`.

--- a/vars/inDockerAgent.groovy
+++ b/vars/inDockerAgent.groovy
@@ -3,8 +3,9 @@ import static com.salemove.Collections.addWithoutDuplicates
 def call(Map args = [:], Closure body) {
   def defaultArgs = [
     name: 'pipeline-docker-build',
-    containers: [agentContainer(image: 'salemove/jenkins-agent-docker:17.12.0-be4ccb0')],
-    volumes: [hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
+    containers: [agentContainer(image: 'salemove/jenkins-agent-docker:19.03.15')],
+    volumes: [hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
+    useBuildKit: false
   ]
 
   // For containers and volumes (list arguments), add the lists together, but
@@ -18,7 +19,12 @@ def call(Map args = [:], Closure body) {
     volumes: finalVolumes
   ]
 
+  def useBuildKit = finalArgs.useBuildKit ? '1' : '0'
+  finalArgs.remove('useBuildKit')
+
   inPod(finalArgs) {
-    body()
+    withEnv(["DOCKER_BUILDKIT=${useBuildKit}"]) {
+      body()
+    }
   }
 }


### PR DESCRIPTION
Initially, it is an "opt-in" feature as BuildKit is still considered
experimental.

Users can turn it on like this:
```
inDockerAgent(useBuildKit: true)
```